### PR TITLE
Refactor: Use ApiClient and improve API communication

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-09T12:48:23.171739200Z">
+        <DropdownSelection timestamp="2025-03-09T13:56:04.033469500Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Janik\.android\avd\Medium_Phone.avd" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/com/app/fotoparadiesauftragchecker/api/ApiClient.kt
+++ b/app/src/main/java/com/app/fotoparadiesauftragchecker/api/ApiClient.kt
@@ -1,0 +1,46 @@
+package com.app.fotoparadiesauftragchecker.api
+
+// Wir vermeiden die Abhängigkeit von BuildConfig
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * Zentrale Singleton-Klasse für die API-Konfiguration.
+ * Stellt eine einheitliche Retrofit-Instanz und API-Service bereit.
+ */
+object ApiClient {
+    private const val TIMEOUT_SECONDS = 30L
+    
+    // OkHttpClient mit Logging und Timeouts
+    private val okHttpClient by lazy {
+        OkHttpClient.Builder().apply {
+            // Logging immer aktivieren (in Produktionsversionen entfernen oder über Properties steuern)
+            val loggingInterceptor = HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }
+            addInterceptor(loggingInterceptor)
+            
+            // Timeouts konfigurieren
+            connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }.build()
+    }
+    
+    // Zentrale Retrofit-Instanz
+    private val retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(FotoparadiesApi.BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+    
+    // API-Schnittstelle als Singleton
+    val fotoparadiesApi: FotoparadiesApi by lazy {
+        retrofit.create(FotoparadiesApi::class.java)
+    }
+}

--- a/app/src/main/java/com/app/fotoparadiesauftragchecker/api/FotoparadiesApi.kt
+++ b/app/src/main/java/com/app/fotoparadiesauftragchecker/api/FotoparadiesApi.kt
@@ -5,7 +5,7 @@ import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface FotoparadiesApi {
-    @GET("spotapi/orderInfo/forShop")
+    @GET("orderInfo/forShop")
     suspend fun getOrderStatus(
         @Query("config") config: Int = OrderStatus.DEFAULT_CONFIG,
         @Query("shop") shop: Int,
@@ -13,6 +13,6 @@ interface FotoparadiesApi {
     ): OrderStatus
 
     companion object {
-        const val BASE_URL = "https://spot.photoprintit.com/"
+        const val BASE_URL = "https://spot.photoprintit.com/spotapi/"
     }
 }

--- a/app/src/main/java/com/app/fotoparadiesauftragchecker/repository/RepositoryProvider.kt
+++ b/app/src/main/java/com/app/fotoparadiesauftragchecker/repository/RepositoryProvider.kt
@@ -1,10 +1,8 @@
 package com.app.fotoparadiesauftragchecker.repository
 
 import android.content.Context
-import com.app.fotoparadiesauftragchecker.api.FotoparadiesApi
+import com.app.fotoparadiesauftragchecker.api.ApiClient
 import com.app.fotoparadiesauftragchecker.data.AppDatabase
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 
 /**
  * Singleton-Klasse für den Zugriff auf Repositories.
@@ -22,12 +20,8 @@ object RepositoryProvider {
             val database = AppDatabase.getDatabase(context)
             val orderDao = database.orderDao()
             
-            val retrofit = Retrofit.Builder()
-                .baseUrl(FotoparadiesApi.BASE_URL)
-                .addConverterFactory(GsonConverterFactory.create())
-                .build()
-            
-            val api = retrofit.create(FotoparadiesApi::class.java)
+            // Die zentrale API-Instanz aus ApiClient verwenden
+            val api = ApiClient.fotoparadiesApi
             
             orderRepository = OrderRepositoryImpl(api, orderDao)
         }

--- a/app/src/main/java/com/app/fotoparadiesauftragchecker/worker/OrderCheckWorker.kt
+++ b/app/src/main/java/com/app/fotoparadiesauftragchecker/worker/OrderCheckWorker.kt
@@ -3,29 +3,20 @@ package com.app.fotoparadiesauftragchecker.worker
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.app.fotoparadiesauftragchecker.api.FotoparadiesApi
+import com.app.fotoparadiesauftragchecker.api.ApiClient
 import com.app.fotoparadiesauftragchecker.data.AppDatabase
 import com.app.fotoparadiesauftragchecker.data.Order
 import com.app.fotoparadiesauftragchecker.notification.NotificationService
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 
 class OrderCheckWorker(
     context: Context,
     params: WorkerParameters
 ) : CoroutineWorker(context, params) {
 
-    private val api: FotoparadiesApi
+    // Die zentrale API-Instanz aus ApiClient verwenden
+    private val api = ApiClient.fotoparadiesApi
     private val orderDao = AppDatabase.getDatabase(context).orderDao()
     private val notificationService = NotificationService(context)
-
-    init {
-        val retrofit = Retrofit.Builder()
-            .baseUrl("https://spot.photoprintit.com/spotapi/")
-            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-        api = retrofit.create(FotoparadiesApi::class.java)
-    }
 
     override suspend fun doWork(): Result {
         return try {
@@ -33,31 +24,31 @@ class OrderCheckWorker(
             
             orders.forEach { order ->
                 try {
+                    // Status vom API abrufen
                     val status = api.getOrderStatus(
                         order = order.orderId.toInt(),
                         shop = order.retailerId.toIntOrNull() ?: 1320
                     )
 
-                    if (status != null) {
-                        val shouldNotify = !order.notificationSent && 
-                                         order.status != "DELIVERED" && 
-                                         status.status == "DELIVERED"
+                    // Prüfen, ob eine Benachrichtigung gesendet werden soll
+                    val shouldNotify = !order.notificationSent && 
+                                     order.status != "DELIVERED" && 
+                                     status.status == "DELIVERED"
 
-                        orderDao.insertOrder(Order(
-                            orderId = order.orderId,
-                            retailerId = order.retailerId,
-                            status = status.status,
-                            orderName = order.orderName,
-                            notificationSent = order.notificationSent || 
-                                (status.status == "DELIVERED")
-                        ))
+                    orderDao.insertOrder(Order(
+                        orderId = order.orderId,
+                        retailerId = order.retailerId,
+                        status = status.status,
+                        orderName = order.orderName,
+                        notificationSent = order.notificationSent || 
+                            (status.status == "DELIVERED")
+                    ))
 
-                        if (shouldNotify) {
-                            notificationService.showOrderReadyNotification(
-                                order.orderId,
-                                order.retailerId
-                            )
-                        }
+                    if (shouldNotify) {
+                        notificationService.showOrderReadyNotification(
+                            order.orderId,
+                            order.retailerId
+                        )
                     }
                 } catch (e: Exception) {
                     // Log error but continue with other orders


### PR DESCRIPTION
- Introduce `ApiClient` for centralized API configuration.
- Refactor `FotoparadiesApi` to use `orderInfo/forShop` endpoint.
- Implement logging and timeouts in `ApiClient`.
- Update `OrderCheckWorker` to use `ApiClient`.
- Update `RepositoryProvider` to use `ApiClient`.
- Add logging-interceptor dependency.
- Remove direct Retrofit instantiation.
- Remove unnecessary init block in `OrderCheckWorker`.
- Adjust `deploymentTargetSelector.xml` for internal use.